### PR TITLE
Fix Book UniqueID always returning 0

### DIFF
--- a/cmd/packer/root.go
+++ b/cmd/packer/root.go
@@ -162,5 +162,5 @@ func getChapterNameForImagePath(imagePath string) string {
 func getUniqueId(title string) uint32 {
 	hash := fnv.New32()
 	hash.Write([]byte(title))
-	retturn hash.Sum32()
+	return hash.Sum32()
 }

--- a/cmd/packer/root.go
+++ b/cmd/packer/root.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"hash/fnv"
 )
 
 type PackForKindleParams struct {
@@ -133,7 +134,7 @@ func PackMangaForKindle(params PackForKindleParams) error {
 		FixedLayout: true,
 		RightToLeft: !params.LeftToRight,
 		CreatedDate: time.Unix(0, 0),
-		UniqueID:    uint32(time.Unix(0, 0).UnixMilli()),
+		UniqueID:    getUniqueId(mangaTitle),
 	}
 
 	outputFilePath := params.OutputFilePath
@@ -156,4 +157,10 @@ func PackMangaForKindle(params PackForKindleParams) error {
 
 func getChapterNameForImagePath(imagePath string) string {
 	return filepath.Base(filepath.Dir(imagePath))
+}
+
+func getUniqueId(title string) uint32 {
+	hash := fnv.New32()
+	hash.Write([]byte(title))
+	retturn hash.Sum32()
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 var rootCmd = &cobra.Command{
 	Use:     "mapaki",
 	Short:   "A no-brainer manga packer for Kindle.",
-	Version: "1.3",
+	Version: "1.4",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		disableAutoCrop, _ := cmd.Flags().GetBool("disable-auto-crop")
 		leftToRight, _ := cmd.Flags().GetBool("left-to-right")


### PR DESCRIPTION
`UniqueID:    uint32(time.Unix(0, 0).UnixMilli()),`

This always returns a uint32 of 0 which causes multiple books to have the same thumbnail when transferring books using Calibre as the book thumbnails depend on the Book ID to be linked properly.

Changed it to a function that returns a unique uint32 from a hash of the book title. 
This way the book ID will be consistent if you need to reconvert the book later on once new chapters are released, and your thumbnails will match. 

I suggest adding an arg that allows passing the book author through the CLI or default to "Mapaki" as the default Author if none is provided. It's somewhat preferable to Unknown as the Author.  

Thank you for writing this program. 
Makes my book conversion easy and fast.